### PR TITLE
Remove the need for includePath configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,30 +49,6 @@ app/styles/[importFileName].scss
 
 It will automatically install [ember-cli-sass](https://github.com/aexmachina/ember-cli-sass#ember-cli-sass) sass preprocess package.
 
-##### Add app to include path in the Brocfile.js (see [ember-cli-sass](https://github.com/aexmachina/ember-cli-sass#ember-cli-sass) documentation)
-
-```
-var app = new EmberApp({
-    sassOptions: {
-        includePaths: [
-            'app'
-        ]
-    }
-});
-```
-
-vvv---- Deprecated Config ----vvv
-###### config/environment.js
-```
-ENV.sassOptions = {
-  includePaths: [
-    'app'
-  ]
-}
-```
-^^^----------------------------^^^
-
-
 ##### The import file
 You need to add the import file into your main app scss file.
 

--- a/blueprints/style/index.js
+++ b/blueprints/style/index.js
@@ -41,7 +41,7 @@ function addScssToImportFile (name, options) {
           filePath = path.join(options.root, 'app/styles'),
           importScssPath = path.join(filePath, importFile + '.scss'),
           podsDir = options.podsDir ? importFile + '/' : '',
-          newLine = '@import "' + podsDir + options.name + '/style";\n',
+          newLine = '@import "app/' + podsDir + options.name + '/style";\n',
           source;
 
       if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
This PR removes the need to configure Sass includePaths. It does that by simply including `app/` in the generated `@import`. It's kind of a pain to have to configure sass includePaths. It's difficult to debug errors. It's much nicer to have ember-cli-sass-pods Just Work.

This should be backwards compatible since projects with the includePaths configured will work even if new `@imports` point to `app/*`.
