### PR TITLE
Allow nested paths on Windows

### DIFF
--- a/blueprints/style/index.js
+++ b/blueprints/style/index.js
@@ -9,7 +9,9 @@ module.exports = {
   description: 'Generates a style.scss file',
 
   beforeInstall: function (options) {
-      this.podsDir = this._locals(options).fileMap.__path__.replace('/' + options.entity.name, '');
+      // replace \ with / for compatibility with windows-style nested paths
+      this.podsDir = this._locals(options).fileMap.__path__.replace(/\\/g, '/');
+      this.podsDir = this.podsDir.replace('/' + options.entity.name, '');
       this.podsDir = this.podsDir.replace(options.entity.name, '');
 
       if (!options.taskOptions.pod) {


### PR DESCRIPTION
Nested paths on Windows gave the following error:

```
> ember g style some/nested/path
version: 2.3.0-beta.1
installing style
  create app\some\nested\path\style.scss

ENOENT: no such file or directory, open 'C:\project\app\styles\some\nested\path.scss'
Error: ENOENT: no such file or directory, open 'C:\project\app\styles\some\nested\path.scss'
    at Error (native)
    at Object.fs.openSync (evalmachine.<anonymous>:549:18)
    at Object.fs.writeFileSync (evalmachine.<anonymous>:1161:15)
    at addScssToImportFile (C:\project\node_modules\ember-cli-sass-pods\blueprints\style\index.js:54:14)

    at Class.module.exports.afterInstall (C:\project\node_modules\ember-cli-sass-pods\blueprints\style\index.js:33:7)
    at lib$rsvp$$internal$$tryCatch (C:\project\node_modules\rsvp\dist\rsvp.js:493:16)
    at lib$rsvp$$internal$$invokeCallback (C:\project\node_modules\rsvp\dist\rsvp.js:505:17)
    at lib$rsvp$$internal$$publish (C:\project\node_modules\rsvp\dist\rsvp.js:476:11)
    at lib$rsvp$asap$$flush (C:\project\node_modules\rsvp\dist\rsvp.js:1198:9)
    at doNTCallback0 (node.js:407:9)
```

This PR fixes that issue by replacing backslashes (`\`) by forward slashes (`/`) in the file name.
