### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "fs-extra": "^0.16.5",
+    "fs-extra": "^0.30.0",
     "mkdirp": "^0.5.0"
   },
   "ember-addon": {


### PR DESCRIPTION
graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible.

Need to upgrade fs-extra to upgrade to graceful-fs@^4.0.0
